### PR TITLE
Add an infix `eq` method to add extras without need of `+`

### DIFF
--- a/app/src/main/java/com/skydoves/bundlerdemo/MainActivity.kt
+++ b/app/src/main/java/com/skydoves/bundlerdemo/MainActivity.kt
@@ -34,6 +34,7 @@ class MainActivity : AppCompatActivity() {
     intentOf<SecondActivity> {
       +("id" to userInfo.id)
       +("name" to userInfo.nickname)
+      "nickName" eq userInfo.nickname
       putExtra("poster", poster)
       putExtra("posterArray", arrayOf(poster))
       putExtra("posterArrayList", arrayListOf(poster))

--- a/bundler/src/main/java/com/skydoves/bundler/Bundler.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/Bundler.kt
@@ -181,6 +181,17 @@ inline class Bundler(val intent: Intent = Intent()) {
   )
 
   /**
+   * Inserts a key/value pair as an extra element.
+   *
+   * ```
+   * key eq value
+   * ```
+   */
+  infix fun String.eq(value: Any?) = intent.putExtras(
+    com.skydoves.bundler.bundleOf(this to value)
+  )
+
+  /**
    * Removes a previous extra.
    *
    * ```


### PR DESCRIPTION
## Guidelines
Adds an `eq` method to insert extras naturally. For example:

```kotlin
 intentOf<SecondActivity> {
   "nickName" eq userInfo.nickname
    startActivity(this@MainActivity)
 }
```

### Types of changes
Added a new method to `Bundler` without changing any existing methods.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Notes

Kept the method name as `eq` so as to avoid conflict with Kotlin stdlib's `to`. 

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.