### PR TITLE
SingleShotLiveData

### DIFF
--- a/bundler/build.gradle
+++ b/bundler/build.gradle
@@ -1,44 +1,45 @@
 plugins {
-    id 'com.android.library'
-    id 'org.jetbrains.dokka'
-    id 'kotlin-android'
+  id 'com.android.library'
+  id 'org.jetbrains.dokka'
+  id 'kotlin-android'
 }
 
 apply from: "$rootDir/dependencies.gradle"
 
 android {
-    compileSdkVersion versions.compileSdk
-    defaultConfig {
-        minSdkVersion versions.minSdk
-        targetSdkVersion versions.compileSdk
-        versionCode versions.versionCode
-        versionName versions.versionName
-    }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
-    buildFeatures {
-        buildConfig false
-    }
+  compileSdkVersion versions.compileSdk
+  defaultConfig {
+    minSdkVersion versions.minSdk
+    targetSdkVersion versions.compileSdk
+    versionCode versions.versionCode
+    versionName versions.versionName
+  }
+  kotlinOptions {
+    jvmTarget = '1.8'
+  }
+  buildFeatures {
+    buildConfig false
+  }
 }
 
 kotlin {
-    explicitApi()
+  explicitApi()
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    kotlinOptions.freeCompilerArgs += ["-XXLanguage:+InlineClasses"]
-    kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.OptIn"]
+  kotlinOptions.freeCompilerArgs += ["-XXLanguage:+InlineClasses"]
+  kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.OptIn"]
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$versions.androidxAppcompat"
+  implementation "androidx.appcompat:appcompat:$versions.androidxAppcompat"
 
-    // unit test
-    testImplementation "junit:junit:$versions.junit"
-    testImplementation "androidx.test:core:$versions.androidxTest"
-    testImplementation "org.robolectric:robolectric:$versions.robolectric"
-    testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlinVersion"
+  // unit test
+  testImplementation "junit:junit:$versions.junit"
+  testImplementation "androidx.test:core:$versions.androidxTest"
+  testImplementation "org.robolectric:robolectric:$versions.robolectric"
+  testImplementation "androidx.arch.core:core-testing:$versions.archCompomentVersion"
+  testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$versions.mockitoKotlinVersion"
 }
 
 apply plugin: "com.vanniktech.maven.publish"

--- a/bundler/src/main/java/com/skydoves/bundler/ActivityBundleObserveLazy.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/ActivityBundleObserveLazy.kt
@@ -26,6 +26,9 @@ import com.skydoves.bundler.IntentLiveDataProvider.provideIntentLiveData
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a retrieved primitive type of extended data from the Intent.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -48,6 +51,9 @@ inline fun <reified T : Any> Activity.observeBundle(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references primitive type of extended data from the Intent.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -70,6 +76,9 @@ inline fun <reified T : Any?> Activity.observeBundle(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references array type of extended data from the Intent.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -92,6 +101,9 @@ inline fun <reified T : Any> Activity.observeBundleArray(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references array list type of extended data from the Intent.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.

--- a/bundler/src/main/java/com/skydoves/bundler/FragmentBundleObserveLazy.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/FragmentBundleObserveLazy.kt
@@ -26,6 +26,9 @@ import com.skydoves.bundler.IntentLiveDataProvider.provideIntentLiveData
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a retrieved primitive type of extended data from the arguments.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -48,6 +51,9 @@ inline fun <reified T : Any> Fragment.observeBundle(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references primitive type of extended data from the arguments.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -70,6 +76,9 @@ inline fun <reified T : Any?> Fragment.observeBundle(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references array type of extended data from the arguments.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.
@@ -92,6 +101,9 @@ inline fun <reified T : Any> Fragment.observeBundleArray(
  * @author skydoves (Jaewoong Eum)
  *
  * Returns a [LiveData] which has a references array list type of extended data from the arguments.
+ * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+ * a single observer. We can observe only once using one observer. And the observer will be unregistered
+ * from the [SingleShotLiveData] after observing data at once.
  *
  * @param key The name of the desired item.
  * @param defaultValue The value to be returned if no value of the desired type is stored with the given name.

--- a/bundler/src/main/java/com/skydoves/bundler/IntentLiveDataProvider.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/IntentLiveDataProvider.kt
@@ -18,7 +18,6 @@ package com.skydoves.bundler
 
 import androidx.annotation.MainThread
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 
 /**
  * @author skydoves (Jaewoong Eum)
@@ -30,6 +29,9 @@ internal object IntentLiveDataProvider {
 
   /**
    * Provide a [LiveData] which has a primitive and references type of extended data from intent.
+   * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+   * a single observer. We can observe only once using one observer. And the observer will be unregistered
+   * from the [SingleShotLiveData] after observing data at once.
    *
    * @param initialValue An initial value for a new [LiveData].
    */
@@ -38,13 +40,14 @@ internal object IntentLiveDataProvider {
   internal inline fun <reified T : Any?> provideIntentLiveData(
     crossinline initialValue: () -> T?
   ): LiveData<T> {
-    return MutableLiveData<T>().apply {
-      value = initialValue()
-    }
+    return SingleShotLiveData<T>(initialValue())
   }
 
   /**
    * Provide a [LiveData] which has a references array type of extended data from intent.
+   * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+   * a single observer. We can observe only once using one observer. And the observer will be unregistered
+   * from the [SingleShotLiveData] after observing data at once.
    *
    * @param initialValue An initial value for a new [LiveData].
    */
@@ -53,13 +56,14 @@ internal object IntentLiveDataProvider {
   internal inline fun <reified T : Any> provideArrayIntentLiveData(
     crossinline initialValue: () -> Array<T>?
   ): LiveData<Array<T>> {
-    return MutableLiveData<Array<T>>().apply {
-      value = initialValue()
-    }
+    return SingleShotLiveData<Array<T>>(initialValue())
   }
 
   /**
    * Provide a [LiveData] which has a references array list type of extended data from intent.
+   * The implementation of the [LiveData] is a [SingleShotLiveData] that emits data only a single time to
+   * a single observer. We can observe only once using one observer. And the observer will be unregistered
+   * from the [SingleShotLiveData] after observing data at once.
    *
    * @param initialValue An initial value for a new [LiveData].
    */
@@ -68,8 +72,6 @@ internal object IntentLiveDataProvider {
   internal inline fun <reified T : Any> provideArrayListIntentLiveData(
     crossinline initialValue: () -> ArrayList<T>?
   ): LiveData<ArrayList<T>> {
-    return MutableLiveData<ArrayList<T>>().apply {
-      value = initialValue()
-    }
+    return SingleShotLiveData<ArrayList<T>>(initialValue())
   }
 }

--- a/bundler/src/main/java/com/skydoves/bundler/SingleShotLiveData.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/SingleShotLiveData.kt
@@ -26,8 +26,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * @author skydoves (Jaewoong Eum)
  *
- * SingleShotLiveData is an implementation of the [MutableLiveData] for emitting [T] data
- * single time to a single observer.
+ * SingleShotLiveData is an implementation of the [MutableLiveData] that emits [T] data
+ * only a single time to a single observer. We can observe only once using one observer.
+ * And the observer will be unregistered from the [SingleShotLiveData] after observing data at once.
  */
 @PublishedApi
 internal class SingleShotLiveData<T> constructor(
@@ -51,7 +52,7 @@ internal class SingleShotLiveData<T> constructor(
         }
       )
     } else {
-      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+      Log.i(TAG, "SingleShotLiveData already has been emitted data.")
     }
   }
 
@@ -63,7 +64,7 @@ internal class SingleShotLiveData<T> constructor(
         removeObserver(observer)
       }
     } else {
-      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+      Log.i(TAG, "SingleShotLiveData already has been emitted data.")
     }
   }
 
@@ -72,7 +73,7 @@ internal class SingleShotLiveData<T> constructor(
     if (!emitted.get()) {
       super.setValue(value)
     } else {
-      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+      Log.i(TAG, "SingleShotLiveData already has been emitted data.")
     }
   }
 
@@ -80,11 +81,11 @@ internal class SingleShotLiveData<T> constructor(
     if (!emitted.get()) {
       super.postValue(value)
     } else {
-      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+      Log.i(TAG, "SingleShotLiveData already has been emitted data.")
     }
   }
 
   companion object {
-    private const val TAG = "OneShotLiveData"
+    private const val TAG = "SingleShotLiveData"
   }
 }

--- a/bundler/src/main/java/com/skydoves/bundler/SingleShotLiveData.kt
+++ b/bundler/src/main/java/com/skydoves/bundler/SingleShotLiveData.kt
@@ -1,0 +1,90 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.bundler
+
+import android.util.Log
+import androidx.annotation.MainThread
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * @author skydoves (Jaewoong Eum)
+ *
+ * SingleShotLiveData is an implementation of the [MutableLiveData] for emitting [T] data
+ * single time to a single observer.
+ */
+@PublishedApi
+internal class SingleShotLiveData<T> constructor(
+  initialValue: T? = null
+) : MutableLiveData<T>() {
+
+  private val emitted = AtomicBoolean(false)
+
+  init {
+    value = initialValue
+  }
+
+  @MainThread
+  override fun observe(owner: LifecycleOwner, observer: Observer<in T>) {
+    if (emitted.compareAndSet(false, true)) {
+      super.observe(
+        owner,
+        {
+          observer.onChanged(it)
+          removeObserver(observer)
+        }
+      )
+    } else {
+      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+    }
+  }
+
+  @MainThread
+  override fun observeForever(observer: Observer<in T>) {
+    if (emitted.compareAndSet(false, true)) {
+      super.observeForever {
+        observer.onChanged(it)
+        removeObserver(observer)
+      }
+    } else {
+      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+    }
+  }
+
+  @MainThread
+  override fun setValue(value: T?) {
+    if (!emitted.get()) {
+      super.setValue(value)
+    } else {
+      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+    }
+  }
+
+  override fun postValue(value: T?) {
+    if (!emitted.get()) {
+      super.postValue(value)
+    } else {
+      Log.i(TAG, "OneShotLiveData data already has been emitted.")
+    }
+  }
+
+  companion object {
+    private const val TAG = "OneShotLiveData"
+  }
+}

--- a/bundler/src/test/java/com/skydoves/bundler/ActivityBundleObserveLazyTest.kt
+++ b/bundler/src/test/java/com/skydoves/bundler/ActivityBundleObserveLazyTest.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.skydoves.bundler.data.Poster
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -45,6 +46,26 @@ class ActivityBundleObserveLazyTest {
     intLiveData.observeForever(intObserver)
 
     verify(intObserver).onChanged(123)
+  }
+
+  @Test
+  fun observeBundleLazyTwiceTest() {
+    val activity = TestActivity()
+    activity.intent = intentOf {
+      putExtra("int", 123)
+    }
+
+    val intLiveData by activity.observeBundle("int", 0)
+
+    val intObserver0 = mock<Observer<Int>>()
+    intLiveData.observeForever(intObserver0)
+
+    verify(intObserver0).onChanged(123)
+
+    val intObserver1 = mock<Observer<Int>>()
+    intLiveData.observeForever(intObserver1)
+
+    verifyNoMoreInteractions(intObserver1)
   }
 
   @Test

--- a/bundler/src/test/java/com/skydoves/bundler/FragmentBundleObserveLazyTest.kt
+++ b/bundler/src/test/java/com/skydoves/bundler/FragmentBundleObserveLazyTest.kt
@@ -19,6 +19,7 @@ package com.skydoves.bundler
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.skydoves.bundler.data.Poster
 import org.hamcrest.CoreMatchers
 import org.hamcrest.MatcherAssert
@@ -44,6 +45,26 @@ class FragmentBundleObserveLazyTest {
     intLiveData.observeForever(intObserver)
 
     verify(intObserver).onChanged(123)
+  }
+
+  @Test
+  fun observeBundleLazyTwiceTest() {
+    val fragment = TestFragment()
+    fragment.arguments = intentOf {
+      putExtra("int", 123)
+    }.extras
+
+    val intLiveData by fragment.observeBundle("int", 0)
+
+    val intObserver0 = mock<Observer<Int>>()
+    intLiveData.observeForever(intObserver0)
+
+    verify(intObserver0).onChanged(123)
+
+    val intObserver1 = mock<Observer<Int>>()
+    intLiveData.observeForever(intObserver1)
+
+    verifyNoMoreInteractions(intObserver1)
   }
 
   @Test

--- a/bundler/src/test/java/com/skydoves/bundler/SingleShotLiveDataTest.kt
+++ b/bundler/src/test/java/com/skydoves/bundler/SingleShotLiveDataTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Designed and developed by 2020 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.skydoves.bundler
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.Is.`is`
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Config(sdk = [21])
+@RunWith(RobolectricTestRunner::class)
+class SingleShotLiveDataTest {
+
+  @get:Rule
+  var instantExecutorRule = InstantTaskExecutorRule()
+
+  @Test
+  fun observeTest() {
+    val oneShotLiveData = SingleShotLiveData("one")
+
+    val observer = mock<Observer<String>>()
+    oneShotLiveData.observeForever(observer)
+
+    verify(observer).onChanged("one")
+
+    oneShotLiveData.setValue("two")
+
+    verifyNoMoreInteractions(observer)
+  }
+
+  @Test
+  fun observeWithMultipleObserversTest() {
+    val oneShotLiveData = SingleShotLiveData("one")
+
+    val observer0 = mock<Observer<String>>()
+    oneShotLiveData.observeForever(observer0)
+
+    val observer1 = mock<Observer<String>>()
+    oneShotLiveData.observeForever(observer1)
+
+    verify(observer0).onChanged("one")
+    verifyNoMoreInteractions(observer1)
+
+    oneShotLiveData.setValue("two")
+
+    verifyNoMoreInteractions(observer0)
+    verifyNoMoreInteractions(observer1)
+  }
+
+  @Test
+  fun setValueTest() {
+    val oneShotLiveData = SingleShotLiveData("one")
+    assertThat(oneShotLiveData.value, `is`("one"))
+
+    oneShotLiveData.setValue("two")
+    assertThat(oneShotLiveData.value, `is`("two"))
+
+    oneShotLiveData.setValue("three")
+    assertThat(oneShotLiveData.value, `is`("three"))
+
+    val observer = mock<Observer<String>>()
+    oneShotLiveData.observeForever(observer)
+
+    verify(observer).onChanged("three")
+
+    oneShotLiveData.setValue("four")
+    verifyNoMoreInteractions(observer)
+  }
+
+  @Test
+  fun postValueTest() {
+    val oneShotLiveData = SingleShotLiveData("one")
+    assertThat(oneShotLiveData.value, `is`("one"))
+
+    oneShotLiveData.postValue("two")
+    assertThat(oneShotLiveData.value, `is`("two"))
+
+    oneShotLiveData.postValue("three")
+    assertThat(oneShotLiveData.value, `is`("three"))
+
+    val observer = mock<Observer<String>>()
+    oneShotLiveData.observeForever(observer)
+
+    verify(observer).onChanged("three")
+
+    oneShotLiveData.postValue("four")
+    verifyNoMoreInteractions(observer)
+  }
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -17,6 +17,7 @@ ext.versions = [
     junit               : '4.13.1',
     androidxTest        : '1.3.0',
     robolectric         : '4.4',
+    archCompomentVersion: '2.1.0',
     mockitoKotlinVersion: '2.2.0',
 
     // for demo


### PR DESCRIPTION
`SingleShotLiveData` is an implementation of the [MutableLiveData] that emits [T] data only a single time to a single observer. We can observe only once using one observer.